### PR TITLE
Fix compiler error that fails to honour post-increment order in inlin…

### DIFF
--- a/picojpeg.c
+++ b/picojpeg.c
@@ -1733,7 +1733,10 @@ static void convertCb(uint8 dstOfs)
       *pDstG++ = subAndClamp(pDstG[0], cbG);
 
       cbB = (cb + ((cb * 198U) >> 8U)) - 227U;
-      *pDstB++ = addAndClamp(pDstB[0], cbB);
+      pDstB[0] = addAndClamp(pDstB[0], cbB);
+      
+      ++pDstG;
+      ++pDstB;
    }
 }
 /*----------------------------------------------------------------------------*/
@@ -1754,7 +1757,10 @@ static void convertCr(uint8 dstOfs)
       *pDstR++ = addAndClamp(pDstR[0], crR);
 
       crG = ((cr * 183U) >> 8U) - 91;
-      *pDstG++ = subAndClamp(pDstG[0], crG);
+      pDstG[0] = subAndClamp(pDstG[0], crG);
+      
+      ++pDstR;
+      ++pDstG;
    }
 }
 /*----------------------------------------------------------------------------*/

--- a/picojpeg.c
+++ b/picojpeg.c
@@ -1730,7 +1730,7 @@ static void convertCb(uint8 dstOfs)
       int16 cbG, cbB;
 
       cbG = ((cb * 88U) >> 8U) - 44U;
-      *pDstG++ = subAndClamp(pDstG[0], cbG);
+      pDstG[0] = subAndClamp(pDstG[0], cbG);
 
       cbB = (cb + ((cb * 198U) >> 8U)) - 227U;
       pDstB[0] = addAndClamp(pDstB[0], cbB);
@@ -1754,7 +1754,7 @@ static void convertCr(uint8 dstOfs)
       int16 crR, crG;
 
       crR = (cr + ((cr * 103U) >> 8U)) - 179;
-      *pDstR++ = addAndClamp(pDstR[0], crR);
+      pDstR[0] = addAndClamp(pDstR[0], crR);
 
       crG = ((cr * 183U) >> 8U) - 91;
       pDstG[0] = subAndClamp(pDstG[0], crG);


### PR DESCRIPTION
The fix in consistent with other functions.

The problem was corupted images cause by the compiler inlining code and not putting post-inrement in correct place at end of inline code.