### PR TITLE
Optimisations for the feeble computer

### DIFF
--- a/picojpeg.c
+++ b/picojpeg.c
@@ -2155,6 +2155,11 @@ static uint8 decodeNextMCU(void)
             
       gCoeffBuf[0] = dc * pQ[0];
 
+      /* Pre-zero the other coeffs */
+      for (k = 1; k < 64; k++) {
+        gCoeffBuf[k] = 0;
+      }
+
       compACTab = gCompACTab[componentID];
 
       if (gReduce)
@@ -2229,11 +2234,7 @@ static uint8 decodeNextMCU(void)
                   if ((k + r) > 63)
                      return PJPG_DECODE_ERROR;
 
-                  while (r)
-                  {
-                     gCoeffBuf[ZAG[k++]] = 0;
-                     r--;
-                  }
+                  k = (uint8)(k + r);
                }
 
                ac = huffExtend(extraBits, s);
@@ -2247,18 +2248,12 @@ static uint8 decodeNextMCU(void)
                   if ((k + 16) > 64)
                      return PJPG_DECODE_ERROR;
                   
-                  for (r = 16; r > 0; r--)
-                     gCoeffBuf[ZAG[k++]] = 0;
-                  
-                  k--; // - 1 because the loop counter is k
+                  k += (16 - 1); // - 1 because the loop counter is k
                }
                else
                   break;
             }
          }
-         
-         while (k < 64)
-            gCoeffBuf[ZAG[k++]] = 0;
 
          transformBlock(mcuBlock); 
       }

--- a/picojpeg.c
+++ b/picojpeg.c
@@ -403,7 +403,7 @@ static PJPG_INLINE uint8 huffDecode(const HuffTable* pHuffTable, const uint8* pH
 
       if (!pHuffTable->mGetMore[i])
       {
-        if (code <= pHuffTable->mMaxCode[i])
+        if (code < pHuffTable->mMaxCode[i])
            break;
       }
 
@@ -430,7 +430,7 @@ static void huffCreate(const uint8* pBits, HuffTable* pHuffTable)
       
       if (num)
       {
-         pHuffTable->mMaxCode[i] = code + num - 1;
+         pHuffTable->mMaxCode[i] = code + num;
          pHuffTable->mValPtr[i] = j - (uint8)code;
          
          j = (uint8)(j + num);

--- a/picojpeg.c
+++ b/picojpeg.c
@@ -156,7 +156,6 @@ static int16 gLastDC[3];
 typedef struct HuffTableT
 {
    uint8  mGetMore[16];
-   uint8  mMinCode[16];
    uint16 mMaxCode[16];
    uint8  mValPtr[16];
 } HuffTable;
@@ -413,8 +412,7 @@ static PJPG_INLINE uint8 huffDecode(const HuffTable* pHuffTable, const uint8* pH
       code |= getBit();
    }
 
-   j = pHuffTable->mValPtr[i];
-   j = (uint8)(j + (code - pHuffTable->mMinCode[i]));
+   j = (uint8)(pHuffTable->mValPtr[i] + code);
 
    return pHuffVal[j];
 }
@@ -432,11 +430,8 @@ static void huffCreate(const uint8* pBits, HuffTable* pHuffTable)
       
       if (num)
       {
-         // minCode's high byte is never used in huffDecode(),
-         // we might as well drop it right now.
-         pHuffTable->mMinCode[i] = (uint8)code;
          pHuffTable->mMaxCode[i] = code + num - 1;
-         pHuffTable->mValPtr[i] = j;
+         pHuffTable->mValPtr[i] = j - (uint8)code;
          
          j = (uint8)(j + num);
          


### PR DESCRIPTION
Hi,

and thanks for this very small JPEG decoder. I based my Apple II Quicktake 200 decoder on it thanks to its very small memory requirements.

I have hacked it A LOT (including ripping out every JPEG subformat that the Quicktake 200 does not produce, and hand-rewriting core functions into assembly), but I feel these few changes could benefit anybody.

I hope you'll like them :)

- Huffman decoding:
  - we never use mMinCode's high byte, and we subtract mMinCode's low byte from mValPtr unconditionally, so do it when building the tables and drop it entirely.
  - use a dedicated mGetMore bool instead of a special-case mMaxCode 0xFFFF to consume one more byte
  - decodeNextMCU: branch a bit less selecting the Huff tables
- General:
  - getExtendOffset: use arrays instead of functions and switches
  - skipVariableMarker: jump to the desired place much faster than left-shifting 8 times every byte we want to skip

Here is a before/after callgrind run (before on the left, after on the right):
<img width="984" height="873" alt="image" src="https://github.com/user-attachments/assets/06b54551-87bb-4ff4-a3e5-5adfeece58aa" />

Full callgrind logs (gcc -g -O0):
[callgrinds.zip](https://github.com/user-attachments/files/21664478/callgrinds.zip)
